### PR TITLE
Delete providers/nodeinfo/software/fastd directory

### DIFF
--- a/providers/nodeinfo/software/fastd/enabled.py
+++ b/providers/nodeinfo/software/fastd/enabled.py
@@ -1,5 +1,0 @@
-import providers
-
-class Source(providers.DataSource):
-    def call(self):
-        return True

--- a/providers/nodeinfo/software/fastd/version.py
+++ b/providers/nodeinfo/software/fastd/version.py
@@ -1,6 +1,0 @@
-import providers
-from providers.util import call
-
-class Source(providers.DataSource):
-    def call(self):
-        return call(['fastd','-v'])[0].split(' ')[1]


### PR DESCRIPTION
* is not needed anymore because we switched to wireguard
* on new serves w/o fastd, it returns an file not found errer 
* previously the fetched information was not used